### PR TITLE
Release v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.0.2] - 2026-02-06
+
+### Fixed
+- Configuration files are now always read using UTF-8 encoding.
+- Clarified and corrected documentation for configuration path precedence
+  and loader application order.
+
+### Added
+- Added test coverage for Python 3.13 in tox.
+- Declared Python 3.13 support in package classifiers.
+
+---
+
 ## [1.0.1] - 2025-06-15
 
 ### Added

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 
-Copyright (c) 2025 QuisEgoSum
+Copyright (c) 2026 QuisEgoSum
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -110,33 +110,14 @@ The order below defines the **precedence** (higher overrides lower):
 pytest --cov=qstd_config --cov-report=term-missing
 ```
 
+---
+
 ## Compatibility
 
-Tested on Python 3.9–3.12.
+Tested on Python 3.9-3.13.
+
+---
 
 ## License
 
-MIT © QuisEgoSum
-
-```text
-Copyright (c) 2025 QuisEgoSum
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-```
+MIT License

--- a/docs/CONFIG_MANAGER.md
+++ b/docs/CONFIG_MANAGER.md
@@ -30,7 +30,7 @@ manager = ConfigManager(
     default_config_values={"debug": False},
     custom_loaders=[MyLoader()],
     chain_loader_factory=custom_chain_loader_factory,
-    merge_strategy=DeepMergeStrategy,
+    merge_strategy=DeepMergeStrategy(),
 )
 
 config = manager.load_config_model()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qstd-config"
-version = "1.0.1"
+version = "1.0.2"
 description = "Application configuration manager"
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent",
     "Development Status :: 5 - Production/Stable",
 ]

--- a/src/qstd_config/loader/factory.py
+++ b/src/qstd_config/loader/factory.py
@@ -27,16 +27,17 @@ def default_chain_loader_factory(
     followed by a FileLoader (for YAML/JSON/etc), and finally an EnvLoader (for environment variables).
 
     The resulting order of application is:
-        1. Custom loaders (lowest priority, override everything)
+        1. Custom loaders (applied first)
         2. FileLoader
-        3. EnvLoader (highest priority)
+        3. EnvLoader (applied last)
 
     All loaders are merged via the provided ConfigMergeStrategy.
 
     Note:
-        Because the loaders are applied sequentially and merged cumulatively, later loaders
-        override the keys of earlier ones. If you want your custom loaders to take precedence
-        over file or environment sources, include them first in the list.
+        Loaders are applied sequentially; later loaders override earlier ones.
+        In the default factory, environment variables have the highest precedence.
+        Custom loaders are applied first (lowest precedence). To give custom loaders
+        higher precedence, use a custom ChainLoader configuration.
 
     :param model: Pydantic model class for env variable resolution.
     :param paths: List of config file paths to be passed to FileLoader.

--- a/src/qstd_config/loader/file_loader.py
+++ b/src/qstd_config/loader/file_loader.py
@@ -48,7 +48,7 @@ class YamlFileLoader(SingleFileLoaderProtocol):
 
         logger.debug('Reading config file: %s', path)
 
-        with open(path) as f:
+        with open(path, encoding='utf-8') as f:
             data: typing.Optional[typing.Dict[str, typing.Any]] = (
                 yaml.safe_load(f) or {}
             )
@@ -91,7 +91,7 @@ class JsonFileLoader(SingleFileLoaderProtocol):
 
         logger.debug('Reading config file: %s', path)
 
-        with open(path) as f:
+        with open(path, encoding='utf-8') as f:
             data: typing.Optional[typing.Dict[str, typing.Any]] = json.load(f)
             if not isinstance(data, dict):
                 raise InvalidFileContentError(path, type(data))

--- a/src/qstd_config/utils.py
+++ b/src/qstd_config/utils.py
@@ -106,7 +106,7 @@ def get_config_paths(
     """
     Compose and validate configuration file paths from multiple sources.
 
-    Sources (in order of precedence):
+    Sources (effective precedence, highest first): args -> env -> base_paths:
       - `base_paths` (user-provided list)
       - environment variables (`{PROJECT_NAME}_CONFIG` or `CONFIG`)
       - command-line arguments (`--config`, `-c`)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, py310, py311, py312
+envlist = py39, py310, py311, py312, py313
 
 [testenv]
 deps = pytest


### PR DESCRIPTION

### Fixed
- Configuration files are now always read using UTF-8 encoding.
- Clarified and corrected documentation for configuration path precedence
  and loader application order.

### Added
- Added test coverage for Python 3.13 in tox.
- Declared Python 3.13 support in package classifiers.
